### PR TITLE
Added support for tracking additional files.

### DIFF
--- a/js/livepage.js
+++ b/js/livepage.js
@@ -85,6 +85,16 @@ livePage.prototype.scanPage = function(){
 			this.addResource(elements[key].src, 'js', false, false);
 		}
 	}
+
+	if(this.options.monitor_custom == true){
+		elements = document.querySelectorAll('link[rel="livePage"]');
+		for(var key=0; key<elements.length; key++){
+			fileType = elements[key].href.split('.').pop();
+			if (['css','html','less','js'].indexOf(fileType)){
+				this.addResource(elements[key].href, 'custom', false);
+			}
+		}
+	}
 	
 	if(this.options.monitor_html == true){
 		this.addResource(this.url, 'html', false, false);

--- a/js/objects.js
+++ b/js/objects.js
@@ -17,6 +17,7 @@ function Settings(){
 		monitor_less: true,
 		monitor_js: true,
 		monitor_html: true,
+		monitor_custom: true,
 		hosts_session: false,
 		skip_external: true,
 		entire_hosts: false,

--- a/options.html
+++ b/options.html
@@ -24,6 +24,7 @@
 				<li><label><input id="monitor_css" name="monitor_css" type="checkbox" value="true" />CSS</label></li>
 				<li><label><input id="monitor_less" name="monitor_less" type="checkbox" value="true" />LESS</label></li>
 				<li><label><input id="monitor_js" name="monitor_js" type="checkbox" value="true" />JavaScript</label></li>
+				<li><label><input id="monitor_custom" name="monitor_custom" type="checkbox" value="true" />LivePage Links <em>&mdash; Monitor files using &lt;link rel=&quot;livePage&quot; href=&quot;/path/to/file.[html/css/js/less]&quot; /&gt;</em></label></li>
 				<li><label><input id="monitor_html" name="monitor_html" type="checkbox" value="true" />HTML</label></li>
 			</ul>
 		</section>


### PR DESCRIPTION
I've added support for monitoring additional html, css, js and less files using `<link rel="livePage" href="/path/to/file">`.

I've also added a corresponding checkbox to the options page.

This is useful when using frameworks such as AngularJS as much of the site content is loaded asynchronously, while the raw HTML content can still be accessed (and this monitored) by the browser.
