### PR TITLE
Allow checking for livepage

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -85,3 +85,11 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
     });
   }
 });
+
+// Allow detection of extension on mikerogers.io
+chrome.runtime.onMessageExternal.addListener(function(request, sender, sendResponse) {
+  if (sender.url == blacklistedWebsite)
+    return;  // don't allow this web page access
+
+  sendResponse(true);
+});

--- a/js/background.js
+++ b/js/background.js
@@ -88,8 +88,5 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 
 // Allow detection of extension on mikerogers.io
 chrome.runtime.onMessageExternal.addListener(function(request, sender, sendResponse) {
-  if (sender.url == blacklistedWebsite)
-    return;  // don't allow this web page access
-
   sendResponse(true);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,8 @@
   "minimum_chrome_version": "18",
   "offline_enabled": true,
   "author": "Mike Rogers",
-  "homepage_url": "https://chrome.google.com/webstore/detail/livepage/pilnojpmdoofaelbinaeodfpjheijkbh"
+  "homepage_url": "https://chrome.google.com/webstore/detail/livepage/pilnojpmdoofaelbinaeodfpjheijkbh",
+  "externally_connectable": {
+    "matches": ["*://*.mikerogers.io/*"]
+  }
 }


### PR DESCRIPTION
Apologies Mike, 

this change (now tested) allows external websites on any _mikerogers.io_ sub-domains to detect an installation of livepage. By default external sites are not allowed to detect the presence of chrome extensions.