### PR TITLE
Fixes #70: Cannot read property 'refresh_rate' of undefined

### DIFF
--- a/js/livepages.js
+++ b/js/livepages.js
@@ -98,22 +98,23 @@ livePages.prototype.start = function(tab) {
     tabId: tab.id
   });
 
+  function executeScriptsInSerial(scripts) {
+    var script = scripts.splice(0, 1)[0];
+    chrome.tabs.executeScript(tab.id, script, function() {
+      if (scripts.length) {
+        executeScriptsInSerial(scripts);
+      }
+    });
+  }
+
   // Make the page Live
-  chrome.tabs.executeScript(tab.id, {
-    code: 'window.$livePageConfig = ' + JSON.stringify(settings.options) + '; window.$livePage = false;'
-  });
-  chrome.tabs.executeScript(tab.id, {
-    file: 'js/injected/live_resource.js'
-  });
-  chrome.tabs.executeScript(tab.id, {
-    file: 'js/injected/live_css_resource.js'
-  });
-  chrome.tabs.executeScript(tab.id, {
-    file: 'js/injected/live_img_resource.js'
-  });
-  chrome.tabs.executeScript(tab.id, {
-    file: 'js/injected/livepage.js'
-  });
+  executeScriptsInSerial([
+    { code: 'window.$livePageConfig = ' + JSON.stringify(settings.options) + '; window.$livePage = false;' },
+    { file: 'js/injected/live_resource.js' },
+    { file: 'js/injected/live_css_resource.js' },
+    { file: 'js/injected/live_img_resource.js' },
+    { file: 'js/injected/livepage.js' }
+  ]);
 }
 
 // Turns off live page on the tab.


### PR DESCRIPTION
I noticed that `chrome.tabs.executeScript` [accepts a callback](https://developer.chrome.com/extensions/tabs#method-executeScript) for when the script has been injected and executed.

So I just updated the code to run each script in serial, with no chance of a script running before another.

I ran some tests, previously I would see the 'cannot read property refresh_rate of undefined' error appear on average every 1 out of 3 refreshes. With this change, after 50 refreshes I didn't see the error once. 😄 