### PR TITLE
Fixes #88

### DIFF
--- a/js/injected/live_resource.js
+++ b/js/injected/live_resource.js
@@ -67,7 +67,7 @@ LiveResource.prototype.check = function(callback) {
       }
     }
   }
-  this.xhr.onerror = function(){}
+  this.xhr.onerror = function(){};
   this.xhr.send();
 }
 

--- a/js/injected/live_resource.js
+++ b/js/injected/live_resource.js
@@ -67,7 +67,7 @@ LiveResource.prototype.check = function(callback) {
       }
     }
   }
-
+  this.xhr.onerror = function(){}
   this.xhr.send();
 }
 


### PR DESCRIPTION
Fixes the error caused by an empty xhr response. This keeps the extension from crashing.