### PR TITLE
Fix Caching remove cache breaker

### DIFF
--- a/js/injected/live_css_resource.js
+++ b/js/injected/live_css_resource.js
@@ -32,7 +32,7 @@ LiveCSSResource.prototype.refresh = function(){
 
   cssElement.setAttribute("type", "text/css");
   cssElement.setAttribute("rel", "stylesheet");
-  cssElement.setAttribute("href", this.nonCacheURL() + "?LivePage=" + new Date() * 1);
+  cssElement.setAttribute("href", this.nonCacheURL());
   cssElement.setAttribute("media", this.media);
 
   // Replace the new one in the palace of the old one.

--- a/js/injected/live_img_resource.js
+++ b/js/injected/live_img_resource.js
@@ -14,5 +14,5 @@ LiveImgResource.prototype.constructor = LiveImgResource;
  * Refresh the element in place
  */
 LiveImgResource.prototype.refresh = function(){
-  this.element.setAttribute("src", this.nonCacheURL() + "?LivePage=" + new Date() * 1);
+  this.element.setAttribute("src", this.nonCacheURL());
 }

--- a/js/injected/live_resource.js
+++ b/js/injected/live_resource.js
@@ -15,9 +15,9 @@ LiveResource.prototype.xhr = null;
  */
 LiveResource.prototype.nonCacheURL = function() {
   if (this.url.indexOf('?') > 0) {
-    return this.url + '&livePage=' + (new Date() * 1);
+    return this.url// + '&livePage=' + (new Date() * 1);
   }
-  return this.url + '?livePage=' + (new Date() * 1);
+  return this.url// + '?livePage=' + (new Date() * 1);
 }
 
 
@@ -31,6 +31,7 @@ LiveResource.prototype.check = function(callback) {
   this.xhr = new XMLHttpRequest();
 
   this.xhr.open("GET", this.nonCacheURL());
+  this.xhr.setRequestHeader('Cache-Control', 'no-cache');
 
   // Timeout or error, remove the resource
   this.xhr.ontimeout = this.xhr.onerror = function(){
@@ -112,7 +113,7 @@ LiveResource.prototype.tidyCode = function(html) {
     html = html.replace(/href\=\"\/cdn-cgi\/l\/email-protection#(.*?)"/gim, '');
 
     // Remove references to LivePages cache breaker
-    html = html.replace(/livePage=([0-9]+)/gim, '');
+    //html = html.replace(/livePage=([0-9]+)/gim, '');
 
     // Ignore doubleclick links
     html = html.replace(/"https:\/\/ad.doubleclick.net(.*?)"/gim, '');


### PR DESCRIPTION
hi again, i see you applied my pull partially, well please note you can also use the xhr cache header in` js/injected/live_resource.js` to get rid of the dirty workaround cache url parameter which creates ugly log entries and make you stand out. 
``this.xhr.setRequestHeader('Cache-Control', 'no-cache');``

the whole (non/)CacheURL logic could be simplified indeed if this header is enough for the same non cached result as it was in my results tested on many live production servers.. this patch just a quick poc for header usage instead of uri parameters

that works from me checked from chrome v60 stable no older version tried.

_for HTTP1.0 it would be Pragma no-cache i believe.. may be for compatiblity for very old web servers to be added._


hope this helps
